### PR TITLE
Add double options and fix double after split bug

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -211,7 +211,7 @@ const getHandInfo = (playerCards, dealerCards) => {
   const hasBlackjack = isBlackjack(playerCards)
   const hasBusted = handValue.hi > 21
   const isClosed = hasBusted || hasBlackjack
-  const canDoubleDown = handValue.hi >= 9 && handValue.hi <= 15 && !isClosed
+  const canDoubleDown = !isClosed
   const canSplit = playerCards.length > 1 && playerCards[ 0 ].value === playerCards[ 1 ].value && !isClosed
   const canEnsure = dealerCards[ 0 ].value === 1 && !isClosed
   return {
@@ -252,6 +252,7 @@ const getHandInfoAfterSplit = (playerCards, dealerCards, initialBet) => {
   hand.availableActions = Object.assign(availableActions, {
     stand: false,
     split: false,
+    double: false,
     insurance: false,
     surrender: false
   })
@@ -263,7 +264,7 @@ const getHandInfoAfterHit = (playerCards, dealerCards, initialBet) => {
   const hand = getHandInfo(playerCards, dealerCards)
   const availableActions = hand.availableActions
   hand.availableActions = Object.assign(availableActions, {
-    double: false,
+    double: (playerCards.length == 2),
     split: false,
     insurance: false,
     surrender: false

--- a/src/game.js
+++ b/src/game.js
@@ -33,9 +33,9 @@ const getDefaultSideBets = (active = false) => {
 const getRules = ({
   decks = 1,
   standOnSoft17 = true,
-  double = true,
+  double = "any",       // none, any, 9or10, 9or10or11, or 9thru15
   split= true,
-  doubleAfterSplit = true,
+  doubleAfterSplit = true,  // What you can double on follows double rule
   surrender = true,
   insurance = true,
   showdownAfterAceSplit = true
@@ -97,10 +97,19 @@ class Game {
     this._dispatch = this._dispatch.bind(this)
   }
 
+  canDouble (double, playerValue) {
+    if (double == "none") return false
+    else if (double == "9or10") return ((playerValue.hi == 9) || (playerValue.hi == 10))
+    else if (double == "9or10or11") return ((playerValue.hi >= 9) && (playerValue.hi <= 11))
+    else if (double == "9thru15") return ((playerValue.hi >= 9) && (playerValue.hi <= 15))
+    else return true;
+  }
+
   enforceRules (handInfo) {
     const { availableActions } = handInfo
+    const { playerValue } = handInfo
     const { rules, history } = this.state
-    if (!rules.double) {
+    if (!this.canDouble(rules.double, playerValue)) {
       availableActions.double = false
     }
     if (!rules.split) {


### PR DESCRIPTION
I created some new double options found in different casinos - either double on any two cards, totals of 9 or 10, totals of 9-11, and the original 9-15 that you had.  I also fixed an issue with doubling after split; it was allowing double immediately after split (when you only have one card in the hand).  Now it waits until there are two cards to allow a double, subject to the doubling rules.