### PR TITLE
Noinsurance

### DIFF
--- a/examples/basicUI/public/index.html
+++ b/examples/basicUI/public/index.html
@@ -45,8 +45,9 @@
                 </div>
                 <div class="panel-footer text-center">
                     <div class="btn-group" role="group">
-                        <button type="button" data-position="left" data-action="stand" disabled class="btn btn-default">Stand</button>
                         <button type="button" data-position="left" data-action="insurance" disabled class="btn btn-default">Insurance</button>
+                        <button type="button" data-position="left" data-action="noinsurance" disabled class="btn btn-default">No Insurance</button>
+                        <button type="button" data-position="left" data-action="stand" disabled class="btn btn-default">Stand</button>
                         <button type="button" data-position="left" data-action="hit" disabled class="btn btn-default">Hit</button>
                         <button type="button" data-position="left" data-action="double" disabled class="btn btn-default">Double</button>
                         <button type="button" data-position="left" data-action="split" disabled class="btn btn-default">Split</button>
@@ -65,8 +66,9 @@
                 </div>
                 <div class="panel-footer text-center">
                     <div class="btn-group" role="group">
-                        <button type="button" data-position="right" data-action="stand" disabled class="btn btn-default">Stand</button>
                         <button type="button" data-position="right" data-action="insurance" data-value="1" disabled class="btn btn-default">Insurance</button>
+                        <button type="button" data-position="right" data-action="noinsurance" data-value="1" disabled class="btn btn-default">No Insurance</button>
+                        <button type="button" data-position="right" data-action="stand" disabled class="btn btn-default">Stand</button>
                         <button type="button" data-position="right" data-action="hit" disabled class="btn btn-default">Hit</button>
                         <button type="button" data-position="right" data-action="double" disabled class="btn btn-default">Double</button>
                         <button type="button" data-position="right" data-action="split" disabled class="btn btn-default">Split</button>

--- a/src/actions.js
+++ b/src/actions.js
@@ -52,6 +52,12 @@ module.exports.insurance = ({bet = 1}) => {
   }
 }
 
+module.exports.noinsurance = () => {
+  return {
+    type: 'NOINSURANCE'
+  }
+}
+
 module.exports.split = () => {
   return {
     type: 'SPLIT'

--- a/src/engine.js
+++ b/src/engine.js
@@ -213,7 +213,7 @@ const getHandInfo = (playerCards, dealerCards) => {
   const isClosed = hasBusted || hasBlackjack
   const canDoubleDown = !isClosed
   const canSplit = playerCards.length > 1 && playerCards[ 0 ].value === playerCards[ 1 ].value && !isClosed
-  const canEnsure = dealerCards[ 0 ].value === 1 && !isClosed
+  const canEnsure = dealerCards[ 0 ].value === 1
   return {
     cards: playerCards,
     playerValue: handValue,
@@ -226,6 +226,7 @@ const getHandInfo = (playerCards, dealerCards) => {
       double: canDoubleDown,
       split: canSplit,
       insurance: canEnsure,
+      noinsurance: canEnsure,
       hit: !isClosed,
       stand: !isClosed,
       surrender: !isClosed
@@ -243,7 +244,7 @@ const getHandInfoAfterDeal = (playerCards, dealerCards, initialBet) => {
     hit: true,
     surrender: true
   })
-  return Object.assign(hand, {close: hand.playerHasBlackjack ? true : false})
+  return Object.assign(hand, {close: (hand.playerHasBlackjack && (dealerCards[0].value != 1)) ? true : false})
 }
 
 const getHandInfoAfterSplit = (playerCards, dealerCards, initialBet) => {
@@ -254,6 +255,7 @@ const getHandInfoAfterSplit = (playerCards, dealerCards, initialBet) => {
     split: false,
     double: false,
     insurance: false,
+    noinsurance: false,
     surrender: false
   })
   hand.bet = initialBet
@@ -267,6 +269,7 @@ const getHandInfoAfterHit = (playerCards, dealerCards, initialBet) => {
     double: (playerCards.length == 2),
     split: false,
     insurance: false,
+    noinsurance: false,
     surrender: false
   })
   hand.bet = initialBet
@@ -291,6 +294,7 @@ const getHandInfoAfterStand = (handInfo) => {
       double: false,
       split: false,
       insurance: false,
+      noinsurance: false,
       hit: false,
       stand: false,
       surrender: false
@@ -306,10 +310,12 @@ const getHandInfoAfterSurrender = (handInfo) => {
   })
 }
 
-const getHandInfoAfterInsurance = (handInfo, bet) => {
-  const availableActions = handInfo.availableActions
+const getHandInfoAfterInsurance = (playerCards, dealerCards, bet) => {
+  const hand = getHandInfo(playerCards, dealerCards)
+  const availableActions = hand.availableActions
   availableActions.insurance = false
-  return Object.assign(handInfo, { playerInsuranceValue: bet, availableActions: availableActions })
+  availableActions.noinsurance = false
+  return Object.assign(hand, { playerInsuranceValue: bet, availableActions: availableActions })
 }
 
 const isLuckyLucky = (playerCards, dealerCards) => {
@@ -353,7 +359,7 @@ const isActionAllowed = (actionName, stage) => {
       return ['RESTORE', 'DEAL'].indexOf(actionName) > -1
     }
     case 'player-turn-right': {
-      return ['STAND', 'INSURANCE', 'SURRENDER', 'SPLIT', 'HIT', 'DOUBLE'].indexOf(actionName) > -1
+      return ['STAND', 'INSURANCE', 'NOINSURANCE', 'SURRENDER', 'SPLIT', 'HIT', 'DOUBLE'].indexOf(actionName) > -1
     }
     case 'player-turn-left': {
       return ['STAND', 'HIT', 'DOUBLE'].indexOf(actionName) > -1


### PR DESCRIPTION
Added a new action for "noinsurance."  When the dealer has an ace (if the insurance rule is set), then the player must first select either "insurance" or "noinsurance."  After their selection, the dealer checks their hole card and the game ends if they have a 10.  Also make sure that we give the player an opportunity to take insurance if they have a blackjack.

This also introduces a dealerHoleCard variable, which is dealt when the dealer hand is initially dealt.  After showdown, the dealer will flip over this card and then hit from the deck if they need to keep hitting.  This logic can be extended with "European no-peek" if the dealer has a 10 showing.