### PR TITLE
showdown when player busted on both sides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine-blackjack",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A simple nodeJs engine to play blackjack",
   "main": "index.js",
   "scripts": {

--- a/src/game.js
+++ b/src/game.js
@@ -418,6 +418,12 @@ class Game {
           }, engine.getPrizes(this.state)))
           break
         }
+        if (checkLeftStatus && handInfo.left.playerHasBusted && handInfo.right.playerHasBusted) {
+          this.setState(Object.assign({
+            stage: TYPES.STAGE_DONE
+          }, engine.getPrizes(this.state)))
+          break
+        }
         while(this.getState().stage === TYPES.STAGE_DEALER_TURN){
           this._dispatch(actions.dealerHit())
         }

--- a/test/game.spec.js
+++ b/test/game.spec.js
@@ -40,6 +40,7 @@ const functions = {
   'deal-luckyLucky': () => actions.deal({bet: 10, sideBets: { luckyLucky: 10 }}),
   'split': () => actions.split(),
   'hitR': () => actions.hit({position: 'right'}),
+  'hitL': () => actions.hit({position: 'left'}),
   'standR': () => actions.stand({position: 'right'}),
   'standL': () => actions.stand({position: 'left'}),
   'doubleL': () => actions.double({position: 'left'}),
@@ -240,6 +241,29 @@ describe('Game flow', function () {
     assert.equal(left.close, true, 'L is close')
     assert.equal(left.playerHasBlackjack, true, 'L has BJ')
     assert.equal(right.playerHasBusted, true, 'R has busted')
+  })
+  it('slits bust on both and dealer showdown', function () {
+    const cards = '♠10 ♦10 ♠10 ♦10 ♥2 ♣2 ♠9 ♦9'
+    const actions = ['restore', 'deal', 'split', 'hitR', 'hitR', 'hitL', 'hitL']
+    const rules = {
+      decks: 1,
+      standOnSoft17: true,
+      double: 'any',
+      split: true,
+      doubleAfterSplit: true,
+      surrender: true,
+      insurance: true,
+      showdownAfterAceSplit: true
+    }
+    const state = executeFlow(rules, cards, actions.map(x => functions[x]))
+    const { stage, handInfo: { left, right}, dealerCards, finalWin = -1 } = state
+    assert.equal(stage, 'done', cards)
+    assert.equal(left.close, true, 'L is close')
+    assert.equal(left.close, true, 'L is close')
+    assert.equal(right.playerHasBusted, true, 'R has busted')
+    assert.equal(left.playerHasBusted, true, 'L has busted')
+    assert.equal(dealerCards.length, 2, 'dealer has 2 cards')
+    assert.equal(finalWin, 0, 'player lose')
   })
 })
 


### PR DESCRIPTION
## Test

```javascript
const cards = '♠10 ♦10 ♠10 ♦10 ♥2 ♣2 ♠9 ♦9'
const actions = ['restore', 'deal', 'split', 'hitR', 'hitR', 'hitL', 'hitL']
```

It was failing, stage was still `DEALER_TURN`
Signed-off-by: Marco Casula <mc@clickbit.net>